### PR TITLE
V2 constraint

### DIFF
--- a/api/v2/app/interfaces/job/manticore/core-image-settings.js
+++ b/api/v2/app/interfaces/job/manticore/core-image-settings.js
@@ -33,7 +33,7 @@ function generateJobFile (jobName, body) {
         job.addEnv(groupName, taskName, envName, info.envs[envName]);
     }
     job.addConstraint({
-        LTarget: "${meta.core}",
+        LTarget: "${meta.job}",
         Operand: "=",
         RTarget: "1"
     }, groupName);

--- a/api/v2/app/interfaces/job/manticore/hmi-image-settings.js
+++ b/api/v2/app/interfaces/job/manticore/hmi-image-settings.js
@@ -30,7 +30,7 @@ function generateJobFile (job, body, envs) {
         job.addEnv(groupName, taskName, envName, info.envs[envName]);
     }
     job.addConstraint({
-        LTarget: "${meta.core}",
+        LTarget: "${meta.job}",
         Operand: "=",
         RTarget: "1"
     }, groupName);


### PR DESCRIPTION
All Manticore job servers running 2.0 must change their Nomad agent file's constraint from "core" to "job" in the meta stanza and must restart the agent after this gets merged