### PR TITLE
Release/2.8.0

### DIFF
--- a/api/v2/app/interfaces/job/manticore/index.js
+++ b/api/v2/app/interfaces/job/manticore/index.js
@@ -18,7 +18,7 @@ const HMI_HEALTH_TIME = 8000;
 
 const jobInfo = {
     core: {
-        versions: ["7.1.0"], //ex. 5.0.1, master, develop
+        versions: ["7.1.1"], //ex. 5.0.1, master, develop
         builds: ["default"]
     }, 
     hmis: [{
@@ -313,7 +313,7 @@ function formatAddresses (id, services) {
 function exampleJobOption () {
     return {
         core: {
-            version: "7.1.0",
+            version: "7.1.1",
             build: "default"
         },
         hmi: {

--- a/api/v2/app/interfaces/job/manticore/index.js
+++ b/api/v2/app/interfaces/job/manticore/index.js
@@ -18,12 +18,12 @@ const HMI_HEALTH_TIME = 8000;
 
 const jobInfo = {
     core: {
-        versions: ["7.0.0"], //ex. 5.0.1, master, develop
+        versions: ["7.1.0"], //ex. 5.0.1, master, develop
         builds: ["default"]
     }, 
     hmis: [{
         type: "generic",
-        versions: ["minimal-0.9.0"] //ex. master, minimal-0.5.1
+        versions: ["minimal-0.10.0"] //ex. master, minimal-0.5.1
     }]
 };
 
@@ -313,12 +313,12 @@ function formatAddresses (id, services) {
 function exampleJobOption () {
     return {
         core: {
-            version: "7.0.0",
+            version: "7.1.0",
             build: "default"
         },
         hmi: {
             type: "generic",
-            version: "minimal-0.9.0"
+            version: "minimal-0.10.0"
         }
     };
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "manticore",
-  "version": "2.7.0",
+  "version": "2.8.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "manticore",
-  "version": "2.7.0",
+  "version": "2.8.0",
   "description": "",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
# 2.8.0 (May 17, 2021)

Manticore will now support [SDL Core 7.1.1](https://github.com/smartdevicelink/sdl_core/releases/tag/7.1.1) and [Generic HMI 0.10.0](https://github.com/smartdevicelink/generic_hmi/releases/tag/0.10.0)

## Completed Features / Enhancements 

- [[SDL 0236] Update mismatch in TireStatus structure](https://github.com/smartdevicelink/manticore/issues/123)

- [[SDL 0255] Enhance BodyInformation vehicle data](https://github.com/smartdevicelink/manticore/issues/122)

- [[SDL 0262] New vehicle data SeatOccupancy](https://github.com/smartdevicelink/manticore/issues/97)

- [[SDL 0267] Main Menu UI Updates](https://github.com/smartdevicelink/manticore/issues/124)

- [[SDL 0269] New vehicle data ClimateData ](https://github.com/smartdevicelink/manticore/issues/102)

- [[SDL 0273] WebEngine Projection mode](https://github.com/smartdevicelink/manticore/issues/118)

- [Manticore UI Policy Server URL Change](https://github.com/smartdevicelink/manticore/issues/111)

## Bug Fixes

- [Toggling the HMI theme is broken](https://github.com/smartdevicelink/manticore/issues/138)

- [PerformInteractions sent quickly after CICS RPCs do not cause highlighted VR commands in the Manticore UI ](https://github.com/smartdevicelink/manticore/issues/143)

- [Bugfix/2.8.0 vulnerabilities](https://github.com/smartdevicelink/manticore/pull/145)

If you have any questions about this release or Manticore in general, please join us in the `#manticore` channel of our public [Slack Organization](http://slack.smartdevicelink.com/).
