### PR TITLE
Remove health check ping for TCP core docker port

### DIFF
--- a/api/v2/app/interfaces/job/manticore/core-image-settings.js
+++ b/api/v2/app/interfaces/job/manticore/core-image-settings.js
@@ -103,15 +103,7 @@ function configurationToImageInfo (coreVersion, coreBuild, id) {
             },
             {
                 name: `core-tcp-${id}`,
-                port: "tcp",
-                checks: [
-                    {
-                        Type: "tcp",
-                        Interval: 3000000000, //3 seconds
-                        Timeout: 1000000000, //1 second
-                        Protocol: "tcp"
-                    }
-                ]
+                port: "tcp"
             },
             {
                 name: `core-file-${id}`,


### PR DESCRIPTION
This change removes the constant pinging of the TCP port which sdl_core believes is a repeated device connection and disconnection. The nature of the removal of the check allows Manticore to recognize the TCP port as a service and will send the address information to the client still.